### PR TITLE
EthersSafeFactory on RSK Testnet and RSK Mainnet

### DIFF
--- a/src/EthersSafeFactory.ts
+++ b/src/EthersSafeFactory.ts
@@ -9,6 +9,7 @@ import {
   recoverDeployedProxy,
   deployProxyFactory
 } from './contracts'
+import { MAINNET_SAFE_DEPLOYMENT, TESTNET_SAFE_DEPLOYMENT } from './constants'
 
 class EthersSafeFactory {
   private signer: Signer
@@ -48,6 +49,20 @@ class EthersSafeFactory {
     const gnosisSafeAddress = await recoverDeployedProxy(receipt)
     return await EthersSafe.create(ethers, gnosisSafeAddress, this.signer)
   }
+
+  public static createSafeFactoryOnRskTestnet = (signer: Signer): EthersSafeFactory =>
+    new EthersSafeFactory(
+      signer,
+      TESTNET_SAFE_DEPLOYMENT.proxyFactoryAddress,
+      TESTNET_SAFE_DEPLOYMENT.safeSingletonAddress
+    )
+
+  public static createSafeFactoryOnRskMainnet = (signer: Signer): EthersSafeFactory =>
+    new EthersSafeFactory(
+      signer,
+      MAINNET_SAFE_DEPLOYMENT.proxyFactoryAddress,
+      MAINNET_SAFE_DEPLOYMENT.safeSingletonAddress
+    )
 }
 
 export default EthersSafeFactory

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -7,7 +7,6 @@ export const TESTNET_SAFE_DEPLOYMENT = {
 }
 
 export const MAINNET_SAFE_DEPLOYMENT = {
-  // FIXME: to be defined
-  safeSingletonAddress: '0xffd41b816f2821e579b4da85c7352bf4f17e4fa5',
-  proxyFactoryAddress: '0x5b836117aed4ca4dee8e2e464f97f7f59b426c5a'
+  safeSingletonAddress: '0xc6cfa90ff601d6aac45d8dcf194cf38b91aca368',
+  proxyFactoryAddress: '0x4b1af52ea200baebf79450dbc996573a7b75f65a'
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,2 +1,13 @@
 export const ZERO_ADDRESS = `0x${'0'.repeat(40)}`
 export const EMPTY_DATA = '0x'
+
+export const TESTNET_SAFE_DEPLOYMENT = {
+  safeSingletonAddress: '0xffd41b816f2821e579b4da85c7352bf4f17e4fa5',
+  proxyFactoryAddress: '0x5b836117aed4ca4dee8e2e464f97f7f59b426c5a'
+}
+
+export const MAINNET_SAFE_DEPLOYMENT = {
+  // FIXME: to be defined
+  safeSingletonAddress: '0xffd41b816f2821e579b4da85c7352bf4f17e4fa5',
+  proxyFactoryAddress: '0x5b836117aed4ca4dee8e2e464f97f7f59b426c5a'
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,3 +13,8 @@ export interface DeploymentOptions {
   nonce?: number
   callbackAddress?: string
 }
+
+export interface SafeDeployment {
+  proxyFactoryAddress: string
+  safeSingletonAddress: string
+}

--- a/test/creation.test.ts
+++ b/test/creation.test.ts
@@ -35,10 +35,10 @@ describe('Safe creation', () => {
       ;({ safeSingletonAddress, proxyFactoryAddress } = await setupTests())
     })
 
-    it('should fail if the signer is not connected to a provider', async () => {
+    it('should fail if the signer is not connected to a provider', () => {
       // Used to mock a signer without provider
       const mockedSigner = {}
-      await chai
+      chai
         .expect(
           () =>
             new EthersSafeFactory(mockedSigner as Signer, proxyFactoryAddress, safeSingletonAddress)
@@ -168,6 +168,26 @@ describe('Safe creation', () => {
         }
       )
       await verifyOwnersAndThreshold(safeSdk, owners, 1)
+    })
+  })
+
+  describe('EthersSafeFactory.createSafeFactoryOnRskTestnet', () => {
+    it('should fail if the signer is not connected to a provider', () => {
+      // Used to mock a signer without provider
+      const mockedSigner = {}
+      chai
+        .expect(() => EthersSafeFactory.createSafeFactoryOnRskTestnet(mockedSigner as Signer))
+        .throws('Signer must be connected to a provider')
+    })
+  })
+
+  describe('EthersSafeFactory.createSafeFactoryOnRskMainnet', () => {
+    it('should fail if the signer is not connected to a provider', () => {
+      // Used to mock a signer without provider
+      const mockedSigner = {}
+      chai
+        .expect(() => EthersSafeFactory.createSafeFactoryOnRskMainnet(mockedSigner as Signer))
+        .throws('Signer must be connected to a provider')
     })
   })
 })


### PR DESCRIPTION
Add two methods to create EthersSafeFactory instances configured on RSK Testnet and RSK Mainnet